### PR TITLE
Fix-epub-conversion

### DIFF
--- a/tests/test_base_builder_loose_blockquote_lists.py
+++ b/tests/test_base_builder_loose_blockquote_lists.py
@@ -1,0 +1,28 @@
+from books.base_builder import BaseBookBuilder
+
+
+def test_make_blockquote_lists_loose_inserts_blank_quote_lines_between_items() -> None:
+    input_md = (
+        "> **Key Terms/Concepts**\n> *Tyranny of the majority* - A\n> *Social tyranny* - B\n> *Harm principle* - C\n"
+    )
+    expected_md = (
+        "> **Key Terms/Concepts**\n"
+        ">\n"
+        "> *Tyranny of the majority* - A\n"
+        ">\n"
+        "> *Social tyranny* - B\n"
+        ">\n"
+        "> *Harm principle* - C\n"
+    )
+
+    assert BaseBookBuilder.make_blockquote_lists_loose(input_md) == expected_md
+
+
+def test_make_blockquote_lists_loose_does_not_double_insert_when_already_loose() -> None:
+    input_md = "> **Key Terms/Concepts**\n>\n> *Tyranny of the majority* - A\n>\n> *Social tyranny* - B\n"
+    assert BaseBookBuilder.make_blockquote_lists_loose(input_md) == input_md
+
+
+def test_make_blockquote_lists_loose_does_not_change_non_blockquote_lists() -> None:
+    input_md = "* A\n* B\n"
+    assert BaseBookBuilder.make_blockquote_lists_loose(input_md) == input_md


### PR DESCRIPTION
Fixes to the EPUB rendering.

1. Add argument to EPUB conversion that fixes 'Send to Kindle' error
2. Turn quote blocks to 'loose lists' for better rendering

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced spacing and formatting of blockquote-style lists within Markdown documents, improving rendering quality in EPUB and PDF exports

* **Changes**
  * Updated EPUB output format from epub to epub2 for improved compatibility and format support

* **Tests**
  * Added comprehensive test coverage for blockquote list spacing functionality, including validation of edge cases

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->