### PR TITLE
Handle EmptySectionError in post-processing to stop pipeline execution

### DIFF
--- a/src/llm_phase.py
+++ b/src/llm_phase.py
@@ -870,6 +870,10 @@ class StandardLlmPhase(LlmPhase):
             logger.debug("Empty block body, returning header only")
             return f"{current_header}\n\n"
 
+        except EmptySectionError:
+            # EmptySectionError is a critical validation error that should stop the pipeline
+            logger.error("EmptySectionError in block processing - propagating to stop pipeline")
+            raise
         except Exception as e:
             logger.error(f"Error processing block: {str(e)}")
             return current_block
@@ -948,6 +952,10 @@ class IntroductionAnnotationPhase(LlmPhase):
                 logger.debug("Empty block body, returning header only")
                 return f"{current_header}\n\n"
 
+        except EmptySectionError:
+            # EmptySectionError is a critical validation error that should stop the pipeline
+            logger.error("EmptySectionError in block processing - propagating to stop pipeline")
+            raise
         except Exception as e:
             logger.error(f"Error processing block: {str(e)}")
             logger.exception("Stack trace for block processing error")
@@ -1028,6 +1036,10 @@ class SummaryAnnotationPhase(LlmPhase):
                 logger.debug("Empty block body, returning header only")
                 return f"{current_header}\n\n"
 
+        except EmptySectionError:
+            # EmptySectionError is a critical validation error that should stop the pipeline
+            logger.error("EmptySectionError in block processing - propagating to stop pipeline")
+            raise
         except Exception as e:
             logger.error(f"Error processing block: {str(e)}")
             logger.exception("Stack trace for block processing error")


### PR DESCRIPTION
Make sure the "EmptySectionError" propagates correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pipeline now halts when an empty content section is detected, preventing partial or misleading outputs.

* **Refactor**
  * Unified exception handling so empty-section errors are propagated consistently, improving reliability and making failure modes clearer for users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->