### PR TITLE
Add llm_kwargs support for provider-specific LLM parameters

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,7 +140,7 @@ Phases inherit from `LlmPhase` (abstract base class) and implement specific proc
 
 ### Configuration-Driven Design
 The system uses dataclasses (`PhaseConfig`, `RunConfig`) for type-safe configuration:
-- `PhaseConfig`: Per-phase settings including model, temperature, prompts, post-processors
+- `PhaseConfig`: Per-phase settings including model, temperature, prompts, post-processors, and `llm_kwargs` for provider-specific parameters
 - `RunConfig`: Pipeline-level settings including phases, length reduction, tags to preserve, `start_from_phase` for resuming
 
 **Important**: Phases are configured declaratively and instantiated through `PhaseFactory`.
@@ -163,6 +163,30 @@ The system supports multiple providers via direct SDK integration:
 - **OpenRouter**: API proxy for various models (set `OPENROUTER_API_KEY`)
 
 Predefined model constants in `src/llm_model.py`: `GEMINI_FLASH`, `GEMINI_PRO`, `OPENAI_04_MINI`, `GROK_3_MINI`, etc.
+
+**Provider-Specific Parameters**: Use the `llm_kwargs` field in `PhaseConfig` to pass additional parameters to LLM calls:
+- **OpenRouter `provider` parameter**: Control routing preferences across multiple model providers
+  - `order`: Prioritized list of provider slugs (e.g., `["openai", "anthropic"]`)
+  - `only`: Allowlist of specific providers to use
+  - `ignore`: Exclude particular providers
+  - `allow_fallbacks`: Enable backup providers if primary is unavailable
+  - `data_collection`: Filter by data privacy practices (`"allow"` or `"deny"`)
+  - `sort`: Order by `"price"`, `"throughput"`, or `"latency"`
+  - `max_price`: Set cost limits per million tokens
+  - `quantizations`: Filter by quantization levels
+
+Example:
+```python
+PhaseConfig(
+    phase_type=PhaseType.MODERNIZE,
+    llm_kwargs={
+        "provider": {
+            "order": ["openai", "anthropic"],
+            "allow_fallbacks": True
+        }
+    }
+)
+```
 
 ### Cost Tracking
 Optional cost tracking via `CostTrackingWrapper`:

--- a/examples/provider_parameter_example.py
+++ b/examples/provider_parameter_example.py
@@ -1,0 +1,122 @@
+"""
+Example script demonstrating how to use OpenRouter's provider parameter for routing control.
+
+The provider parameter allows you to control routing preferences when using OpenRouter,
+including specifying provider order, filtering by data collection policies, and more.
+
+See: https://openrouter.ai/docs/api/api-reference/chat/send-chat-completion-request
+"""
+
+import sys
+from pathlib import Path
+from typing import List
+
+# Add project root to path to allow importing from src
+sys.path.append(str(Path(__file__).parent.parent))
+
+from src.common.provider import Provider
+from src.config import PhaseConfig, PhaseType, RunConfig
+from src.llm_model import GROK_3_MINI, ModelConfig
+from src.pipeline import run_pipeline
+
+
+def main():
+    """Run the pipeline with OpenRouter provider routing preferences."""
+
+    # Example 1: Prioritize specific providers in order
+    provider_with_order = PhaseConfig(
+        phase_type=PhaseType.MODERNIZE,
+        model=GROK_3_MINI,
+        temperature=0.3,
+        llm_kwargs={
+            "provider": {
+                "order": ["openai", "anthropic"],  # Try OpenAI first, then Anthropic
+                "allow_fallbacks": True,  # Allow fallbacks if primary unavailable
+            }
+        },
+    )
+
+    # Example 2: Only use providers that don't collect data
+    provider_privacy_focused = PhaseConfig(
+        phase_type=PhaseType.EDIT,
+        model=ModelConfig(Provider.OPENROUTER, "anthropic/claude-sonnet-4"),
+        temperature=0.2,
+        llm_kwargs={
+            "provider": {
+                "data_collection": "deny",  # Only use providers that don't collect data
+            }
+        },
+    )
+
+    # Example 3: Sort by price (cheapest first)
+    provider_cost_optimized = PhaseConfig(
+        phase_type=PhaseType.FINAL,
+        model=GROK_3_MINI,
+        temperature=0.3,
+        llm_kwargs={
+            "provider": {
+                "sort": "price",  # Sort by price (cheapest first)
+                "allow_fallbacks": True,
+            }
+        },
+    )
+
+    # Example 4: Set maximum price limits
+    provider_budget_limited = PhaseConfig(
+        phase_type=PhaseType.SUMMARY,
+        model=ModelConfig(Provider.OPENROUTER, "anthropic/claude-sonnet-4"),
+        temperature=0.3,
+        llm_kwargs={
+            "provider": {
+                "max_price": {
+                    "prompt": 0.001,  # Max price per million prompt tokens
+                    "completion": 0.005,  # Max price per million completion tokens
+                }
+            }
+        },
+    )
+
+    # Example 5: Exclude specific providers
+    provider_with_exclusions = PhaseConfig(
+        phase_type=PhaseType.ANNOTATE,
+        model=GROK_3_MINI,
+        temperature=0.3,
+        llm_kwargs={
+            "provider": {
+                "ignore": ["provider-a", "provider-b"],  # Exclude specific providers
+            }
+        },
+    )
+
+    # Define phases using different provider configurations
+    run_phases: List[PhaseConfig] = [
+        provider_with_order,
+        provider_privacy_focused,
+        provider_cost_optimized,
+        provider_budget_limited,
+        provider_with_exclusions,
+    ]
+
+    # Create run configuration
+    config = RunConfig(
+        book_id="provider_example",
+        book_name="Provider Example",
+        author_name="Example Author",
+        input_file=Path("books/on_liberty/input_small.md"),
+        output_dir=Path("books/on_liberty/output"),
+        original_file=Path("books/on_liberty/input_small.md"),
+        phases=run_phases,
+    )
+
+    # Run the pipeline
+    print("Running pipeline with provider routing preferences...")
+    print("\nPhase configurations:")
+    for i, phase in enumerate(run_phases, 1):
+        print(f"{i}. {phase.phase_type.name}: {phase.llm_kwargs.get('provider', 'default')}")
+
+    run_pipeline(config)
+    print("\nPipeline completed successfully!")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/config.py
+++ b/src/config.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 from enum import Enum, auto
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
 
 from src.common.provider import Provider
 from src.constants import DEFAULT_LENGTH_REDUCTION_BOUNDS, DEFAULT_TAGS_TO_PRESERVE
@@ -113,6 +113,7 @@ class PhaseConfig:
     )
     temperature: float = 0.2
     reasoning: Optional[dict[str, str]] = None
+    llm_kwargs: Optional[dict[str, Any]] = None
     system_prompt_path: Optional[Path] = None
     user_prompt_path: Optional[Path] = None
     custom_output_path: Optional[Path] = None
@@ -153,6 +154,9 @@ class PhaseConfig:
                         "reasoning must be a dict[str, str]; "
                         f"found key/value types ({type(k).__name__}, {type(v).__name__})"
                     )
+
+        if self.llm_kwargs is not None and not isinstance(self.llm_kwargs, dict):
+            raise TypeError(f"llm_kwargs must be a dict or None, got {type(self.llm_kwargs).__name__}")
 
         if not isinstance(self.use_batch, bool):
             raise TypeError(f"use_batch must be a bool, got {type(self.use_batch).__name__}")

--- a/src/phase_factory.py
+++ b/src/phase_factory.py
@@ -192,6 +192,7 @@ class PhaseFactory:
             "temperature": config.temperature,
             "max_workers": max_workers,
             "reasoning": config.reasoning,
+            "llm_kwargs": config.llm_kwargs,
             "post_processor_chain": post_processor_chain,
             "length_reduction": length_reduction,
             "use_batch": config.use_batch,


### PR DESCRIPTION
Add the ability to pass kwargs to the LLM model (the initial use case is providing provider information to OpenRouter)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now configure provider-specific parameters for LLM providers, enabling control over provider order, data collection, pricing filters, and exclusions

* **Documentation**
  * Added example script demonstrating provider parameter configuration
  * Updated documentation with guidance on using provider-specific options

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->