### PR TITLE
Centralize default temperature using LLM_DEFAULT_TEMPERATURE constant

### DIFF
--- a/examples/annotation_example.py
+++ b/examples/annotation_example.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 from src.common.provider import Provider
 from src.config import PhaseConfig, PhaseType, RunConfig
+from src.constants import LLM_DEFAULT_TEMPERATURE
 from src.llm_model import ModelConfig
 from src.pipeline import Pipeline
 
@@ -25,7 +26,7 @@ def main():
     author_name = "F. Scott Fitzgerald"
     input_file = Path("examples/annotation_input.md")
     output_dir = Path("examples/annotation_output")
-    temperature = 0.2
+    temperature = LLM_DEFAULT_TEMPERATURE
 
     # File paths
     original_file = Path("original.md")

--- a/examples/default_postprocessors_example.py
+++ b/examples/default_postprocessors_example.py
@@ -12,6 +12,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from src.config import PhaseConfig, PhaseType, PostProcessorType
+from src.constants import LLM_DEFAULT_TEMPERATURE
 from src.phase_factory import PhaseFactory
 
 
@@ -31,7 +32,7 @@ def main():
             input_file_path=Path(f"input/{phase_type.name.lower()}.md"),
             output_file_path=Path(f"output/{phase_type.name.lower()}.md"),
             original_file_path=Path("original/gatsby.md"),
-            temperature=0.2,
+            temperature=LLM_DEFAULT_TEMPERATURE,
         )
         for phase_type in PhaseType
     }
@@ -89,7 +90,7 @@ def main():
         input_file_path=Path("input/modernize.md"),
         output_file_path=Path("output/modernize.md"),
         original_file_path=Path("original/gatsby.md"),
-        temperature=0.3,
+        temperature=LLM_DEFAULT_TEMPERATURE,
         # Using string names
         post_processors=["remove_xml_tags", "ensure_blank_line"],
     )
@@ -109,7 +110,7 @@ def main():
         input_file_path=Path("input/modernize.md"),
         output_file_path=Path("output/modernize.md"),
         original_file_path=Path("original/gatsby.md"),
-        temperature=0.3,
+        temperature=LLM_DEFAULT_TEMPERATURE,
         # Using PostProcessorType enum values
         post_processors=[
             PostProcessorType.REMOVE_XML_TAGS,
@@ -134,7 +135,7 @@ def main():
         input_file_path=Path("input/annotate.md"),
         output_file_path=Path("output/annotate.md"),
         original_file_path=Path("original/gatsby.md"),
-        temperature=0.2,
+        temperature=LLM_DEFAULT_TEMPERATURE,
         # Mixing strings, enums, and instances
         post_processors=[
             "revert_removed_block_lines",  # String

--- a/examples/metadata_example.py
+++ b/examples/metadata_example.py
@@ -12,6 +12,7 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).parent.parent))
 
 from src.config import PhaseConfig, PhaseType, RunConfig
+from src.constants import LLM_DEFAULT_TEMPERATURE
 from src.pipeline import Pipeline
 
 
@@ -26,13 +27,13 @@ def main():
         output_dir=Path("examples/output"),
         original_file=Path("examples/original.txt"),
         phases=[
-            PhaseConfig(phase_type=PhaseType.MODERNIZE, enabled=True, temperature=0.2),
+            PhaseConfig(phase_type=PhaseType.MODERNIZE, enabled=True, temperature=LLM_DEFAULT_TEMPERATURE),
             PhaseConfig(
                 phase_type=PhaseType.EDIT,
                 enabled=False,  # This phase will be skipped
-                temperature=0.3,
+                temperature=LLM_DEFAULT_TEMPERATURE,
             ),
-            PhaseConfig(phase_type=PhaseType.ANNOTATE, enabled=True, temperature=0.1),
+            PhaseConfig(phase_type=PhaseType.ANNOTATE, enabled=True, temperature=LLM_DEFAULT_TEMPERATURE),
         ],
     )
 

--- a/examples/phase_factory_example.py
+++ b/examples/phase_factory_example.py
@@ -9,6 +9,8 @@ processor names (strings) and custom processor instances.
 import sys
 from pathlib import Path
 
+from src.constants import LLM_DEFAULT_TEMPERATURE
+
 # Add the parent directory to the path to import src modules
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
@@ -45,7 +47,7 @@ def main():
         input_file_path=Path("input/intro.md"),
         output_file_path=Path("output/intro.md"),
         original_file_path=Path("original/gatsby.md"),
-        temperature=0.2,
+        temperature=LLM_DEFAULT_TEMPERATURE,
         # Only built-in processors
         post_processors=[PostProcessorType.REMOVE_XML_TAGS],
     )

--- a/examples/post_processing_example.py
+++ b/examples/post_processing_example.py
@@ -8,6 +8,7 @@ post-processor configurations to clean up and improve LLM-generated content.
 from pathlib import Path
 
 from src.config import PhaseConfig, PhaseType, PostProcessorType
+from src.constants import LLM_DEFAULT_TEMPERATURE
 from src.llm_model import LlmModel
 from src.phase_factory import PhaseFactory
 from src.post_processors import PostProcessor
@@ -63,7 +64,7 @@ def example_standard_phase_with_post_processing():
         book_name="Example Book",
         author_name="Example Author",
         model=model,
-        temperature=0.2,
+        temperature=LLM_DEFAULT_TEMPERATURE,
         post_processors=[PostProcessorType.PRESERVE_F_STRING_TAGS],
     )
     phase = PhaseFactory.create_standard_phase(config)
@@ -98,7 +99,7 @@ def example_annotation_phase_with_custom_post_processing():
         book_name="Example Book",
         author_name="Example Author",
         model=model,
-        temperature=0.2,
+        temperature=LLM_DEFAULT_TEMPERATURE,
         post_processors=[custom_processor],
     )
     phase = PhaseFactory.create_introduction_annotation_phase(config)
@@ -133,7 +134,7 @@ def example_summary_phase_with_mixed_post_processing():
         book_name="Example Book",
         author_name="Example Author",
         model=model,
-        temperature=0.2,
+        temperature=LLM_DEFAULT_TEMPERATURE,
         post_processors=[PostProcessorType.REVERT_REMOVED_BLOCK_LINES, custom_processor],
     )
     phase = PhaseFactory.create_summary_annotation_phase(config)
@@ -165,7 +166,7 @@ def example_phase_without_post_processing():
         book_name="Example Book",
         author_name="Example Author",
         model=model,
-        temperature=0.2,
+        temperature=LLM_DEFAULT_TEMPERATURE,
         # No post_processors specified, so defaults will be used
     )
     phase = PhaseFactory.create_standard_phase(config)

--- a/examples/provider_parameter_example.py
+++ b/examples/provider_parameter_example.py
@@ -16,6 +16,7 @@ sys.path.append(str(Path(__file__).parent.parent))
 
 from src.common.provider import Provider
 from src.config import PhaseConfig, PhaseType, RunConfig
+from src.constants import LLM_DEFAULT_TEMPERATURE
 from src.llm_model import GROK_3_MINI, ModelConfig
 from src.pipeline import run_pipeline
 
@@ -40,7 +41,7 @@ def main():
     provider_privacy_focused = PhaseConfig(
         phase_type=PhaseType.EDIT,
         model=ModelConfig(Provider.OPENROUTER, "anthropic/claude-sonnet-4"),
-        temperature=0.2,
+        temperature=LLM_DEFAULT_TEMPERATURE,
         llm_kwargs={
             "provider": {
                 "data_collection": "deny",  # Only use providers that don't collect data
@@ -52,7 +53,7 @@ def main():
     provider_cost_optimized = PhaseConfig(
         phase_type=PhaseType.FINAL,
         model=GROK_3_MINI,
-        temperature=0.3,
+        temperature=LLM_DEFAULT_TEMPERATURE,
         llm_kwargs={
             "provider": {
                 "sort": "price",  # Sort by price (cheapest first)
@@ -65,7 +66,7 @@ def main():
     provider_budget_limited = PhaseConfig(
         phase_type=PhaseType.SUMMARY,
         model=ModelConfig(Provider.OPENROUTER, "anthropic/claude-sonnet-4"),
-        temperature=0.3,
+        temperature=LLM_DEFAULT_TEMPERATURE,
         llm_kwargs={
             "provider": {
                 "max_price": {
@@ -80,7 +81,7 @@ def main():
     provider_with_exclusions = PhaseConfig(
         phase_type=PhaseType.ANNOTATE,
         model=GROK_3_MINI,
-        temperature=0.3,
+        temperature=LLM_DEFAULT_TEMPERATURE,
         llm_kwargs={
             "provider": {
                 "ignore": ["provider-a", "provider-b"],  # Exclude specific providers

--- a/examples/retry_example.py
+++ b/examples/retry_example.py
@@ -13,6 +13,7 @@ from pathlib import Path
 # Add the src directory to the path
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
+from src.constants import LLM_DEFAULT_TEMPERATURE
 from src.llm_model import LlmModel, LlmModelError
 
 
@@ -23,7 +24,7 @@ def example_basic_retry():
     # Create model with default retry settings (3 retries, 1s delay, 2x backoff)
     model = LlmModel.create(
         model="google/gemini-2.5-flash",
-        temperature=0.2,
+        temperature=LLM_DEFAULT_TEMPERATURE,
         max_retries=3,
         retry_delay=1.0,
         backoff_factor=2.0,
@@ -44,7 +45,7 @@ def example_custom_retry():
     # Create model with aggressive retry settings
     model = LlmModel.create(
         model="google/gemini-2.5-flash",
-        temperature=0.2,
+        temperature=LLM_DEFAULT_TEMPERATURE,
         max_retries=5,
         retry_delay=0.5,
         backoff_factor=1.5,
@@ -69,7 +70,7 @@ def example_no_retry():
     # Create model with no retries
     model = LlmModel.create(
         model="google/gemini-2.5-flash",
-        temperature=0.2,
+        temperature=LLM_DEFAULT_TEMPERATURE,
         max_retries=0,
         retry_delay=1.0,
         backoff_factor=2.0,
@@ -88,7 +89,7 @@ def example_error_handling():
     # Create model with minimal retries for quick demonstration
     model = LlmModel.create(
         model="google/gemini-2.5-flash",
-        temperature=0.2,
+        temperature=LLM_DEFAULT_TEMPERATURE,
         max_retries=1,
         retry_delay=0.1,
         backoff_factor=1.0,

--- a/examples/tags_to_preserve_example.py
+++ b/examples/tags_to_preserve_example.py
@@ -13,6 +13,7 @@ from typing import List
 sys.path.append(str(Path(__file__).parent.parent))
 
 from src.config import PhaseConfig, PhaseType, RunConfig
+from src.constants import LLM_DEFAULT_TEMPERATURE
 from src.llm_model import GEMINI_PRO, OPENAI_04_MINI
 
 
@@ -81,17 +82,17 @@ def main():
         PhaseConfig(
             phase_type=PhaseType.MODERNIZE,
             model=OPENAI_04_MINI,
-            temperature=0.3,
+            temperature=LLM_DEFAULT_TEMPERATURE,
         ),
         PhaseConfig(
             phase_type=PhaseType.EDIT,
             model=GEMINI_PRO,
-            temperature=0.2,
+            temperature=LLM_DEFAULT_TEMPERATURE,
         ),
         PhaseConfig(
             phase_type=PhaseType.FINAL,
             model=OPENAI_04_MINI,
-            temperature=0.1,
+            temperature=LLM_DEFAULT_TEMPERATURE,
         ),
     ]
 

--- a/src/config.py
+++ b/src/config.py
@@ -10,6 +10,7 @@ from src.constants import (
     DEFAULT_MAX_SUBBLOCK_TOKENS,
     DEFAULT_MIN_SUBBLOCK_TOKENS,
     DEFAULT_TAGS_TO_PRESERVE,
+    LLM_DEFAULT_TEMPERATURE,
     MAX_SUBBLOCK_TOKEN_BOUND,
     MIN_SUBBLOCK_TOKEN_BOUND,
 )
@@ -61,13 +62,14 @@ def _validate_temperature(*, temperature: float) -> None:
         temperature: Sampling temperature. Must be between 0 and 2 (inclusive).
 
     Raises:
-        TypeError: If temperature is not a number.
+        TypeError: If temperature cannot be compared as a number.
         ValueError: If temperature is out of range.
     """
-    if not isinstance(temperature, (int, float)):
-        raise TypeError(f"Temperature must be a number, got {type(temperature).__name__}")
-    if temperature < 0 or temperature > 2:
-        raise ValueError(f"Temperature must be between 0 and 2, got {temperature}")
+    try:
+        if temperature < 0 or temperature > 2:
+            raise ValueError(f"Temperature must be between 0 and 2, got {temperature}")
+    except TypeError as e:
+        raise TypeError(f"Temperature must be a number, got {type(temperature).__name__}") from e
 
 
 def _validate_length_reduction(*, length_reduction: Optional[Union[int, Tuple[int, int]]]) -> None:
@@ -128,8 +130,8 @@ class TwoStageModelConfig:
 
     identify_model: ModelConfig
     implement_model: ModelConfig
-    identify_temperature: float = 0.2
-    implement_temperature: float = 0.2
+    identify_temperature: float = LLM_DEFAULT_TEMPERATURE
+    implement_temperature: float = LLM_DEFAULT_TEMPERATURE
     identify_reasoning: Optional[dict[str, str]] = None
 
     def __post_init__(self) -> None:
@@ -169,7 +171,7 @@ class PhaseConfig:
     model: ModelConfig = field(
         default_factory=lambda: ModelConfig(Provider.GEMINI, "google/gemini-2.5-flash", "gemini-2.5-flash")
     )
-    temperature: float = 0.2
+    temperature: float = LLM_DEFAULT_TEMPERATURE
     reasoning: Optional[dict[str, str]] = None
     llm_kwargs: Optional[dict[str, Any]] = None
     system_prompt_path: Optional[Path] = None

--- a/src/llm_phase.py
+++ b/src/llm_phase.py
@@ -18,6 +18,7 @@ from src.constants import (
     DEFAULT_MAX_WORKERS,
     DEFAULT_MIN_SUBBLOCK_TOKENS,
     DEFAULT_TAGS_TO_PRESERVE,
+    LLM_DEFAULT_TEMPERATURE,
 )
 from src.cost_tracking_wrapper import add_generation_id
 from src.llm_model import (
@@ -49,7 +50,7 @@ class LlmPhase(ABC):
         book_name: str,
         author_name: str,
         model: LlmModel,
-        temperature: float = 0.2,
+        temperature: float = LLM_DEFAULT_TEMPERATURE,
         max_workers: Optional[int] = None,
         reasoning: Optional[Dict[str, str]] = None,
         llm_kwargs: Optional[Dict[str, Any]] = None,
@@ -1612,8 +1613,8 @@ class TwoStageFinalPhase(LlmPhase):
         identify_user_prompt_path: Path,
         implement_system_prompt_path: Path,
         implement_user_prompt_path: Path,
-        identify_temperature: float = 0.2,
-        implement_temperature: float = 0.2,
+        identify_temperature: float = LLM_DEFAULT_TEMPERATURE,
+        implement_temperature: float = LLM_DEFAULT_TEMPERATURE,
         identify_reasoning: Optional[Dict[str, str]] = None,
         max_workers: Optional[int] = None,
         llm_kwargs: Optional[Dict[str, Any]] = None,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,8 @@ from unittest.mock import patch
 
 import pytest
 
+from src.constants import LLM_DEFAULT_TEMPERATURE
+
 
 @pytest.fixture(autouse=True)
 def mock_openrouter_api_key():
@@ -30,7 +32,7 @@ def mock_llm_model():
         # Create a mock instance with necessary attributes
         mock_instance = Mock(spec=LlmModel)
         mock_instance.model_id = "test/model"
-        mock_instance.temperature = 0.2
+        mock_instance.temperature = LLM_DEFAULT_TEMPERATURE
         mock_instance.chat_completion = mock_completion
 
         with patch("src.llm_model.LlmModel", return_value=mock_instance):

--- a/tests/test_system_prompt_metadata.py
+++ b/tests/test_system_prompt_metadata.py
@@ -13,6 +13,7 @@ from unittest.mock import Mock, patch
 sys.path.append(str(Path(__file__).parent.parent))
 
 from src.config import PhaseConfig, PhaseType, RunConfig
+from src.constants import LLM_DEFAULT_TEMPERATURE
 from src.pipeline import Pipeline
 
 
@@ -23,7 +24,7 @@ def test_pipeline_metadata(mock_cost_wrapper, mock_llm_create):
     # Mock the LlmModel.create to avoid API key requirements
     mock_model_instance = Mock()
     mock_model_instance.model_id = "test/model"
-    mock_model_instance.temperature = 0.2
+    mock_model_instance.temperature = LLM_DEFAULT_TEMPERATURE
     mock_llm_create.return_value = mock_model_instance
 
     # Mock the cost wrapper to avoid API dependencies
@@ -60,7 +61,7 @@ def test_pipeline_metadata(mock_cost_wrapper, mock_llm_create):
                     PhaseConfig(
                         phase_type=PhaseType.MODERNIZE,
                         enabled=True,
-                        temperature=0.2,
+                        temperature=LLM_DEFAULT_TEMPERATURE,
                     )
                 ],
                 length_reduction=(35, 50),
@@ -149,7 +150,7 @@ def test_cost_analysis_saving(mock_cost_wrapper, mock_llm_create):
     # Mock the LlmModel.create to avoid API key requirements
     mock_model_instance = Mock()
     mock_model_instance.model_id = "test/model"
-    mock_model_instance.temperature = 0.2
+    mock_model_instance.temperature = LLM_DEFAULT_TEMPERATURE
     mock_llm_create.return_value = mock_model_instance
 
     # Mock the cost wrapper to avoid API dependencies
@@ -186,7 +187,7 @@ def test_cost_analysis_saving(mock_cost_wrapper, mock_llm_create):
                     PhaseConfig(
                         phase_type=PhaseType.MODERNIZE,
                         enabled=True,
-                        temperature=0.2,
+                        temperature=LLM_DEFAULT_TEMPERATURE,
                     )
                 ],
                 length_reduction=(35, 50),
@@ -274,7 +275,7 @@ def test_metadata_with_disabled_phases(mock_cost_wrapper, mock_llm_create):
     # Mock the LlmModel.create to avoid API key requirements
     mock_model_instance = Mock()
     mock_model_instance.model_id = "test/model"
-    mock_model_instance.temperature = 0.2
+    mock_model_instance.temperature = LLM_DEFAULT_TEMPERATURE
     mock_llm_create.return_value = mock_model_instance
 
     # Mock the cost wrapper to avoid API dependencies
@@ -311,7 +312,7 @@ def test_metadata_with_disabled_phases(mock_cost_wrapper, mock_llm_create):
                     PhaseConfig(
                         phase_type=PhaseType.MODERNIZE,
                         enabled=True,
-                        temperature=0.2,
+                        temperature=LLM_DEFAULT_TEMPERATURE,
                     ),
                     PhaseConfig(
                         phase_type=PhaseType.EDIT,
@@ -359,7 +360,7 @@ def test_metadata_with_failed_phases(mock_cost_wrapper, mock_llm_create):
     # Mock the LlmModel.create to avoid API key requirements
     mock_model_instance = Mock()
     mock_model_instance.model_id = "test/model"
-    mock_model_instance.temperature = 0.2
+    mock_model_instance.temperature = LLM_DEFAULT_TEMPERATURE
     mock_llm_create.return_value = mock_model_instance
 
     # Mock the cost wrapper to avoid API dependencies
@@ -396,7 +397,7 @@ def test_metadata_with_failed_phases(mock_cost_wrapper, mock_llm_create):
                     PhaseConfig(
                         phase_type=PhaseType.MODERNIZE,
                         enabled=True,
-                        temperature=0.2,
+                        temperature=LLM_DEFAULT_TEMPERATURE,
                     )
                 ],
                 length_reduction=(35, 50),
@@ -422,7 +423,7 @@ def test_metadata_with_failed_phases(mock_cost_wrapper, mock_llm_create):
             assert failed_phase_metadata["enabled"] is True
             assert failed_phase_metadata["completed"] is False
             assert failed_phase_metadata["reason"] == "not_run"
-            assert failed_phase_metadata["temperature"] == 0.2
+            assert failed_phase_metadata["temperature"] == LLM_DEFAULT_TEMPERATURE
 
             print("✓ Failed phase metadata test passed")
 


### PR DESCRIPTION
Even though the temperature had been set to 1 in the constants file, some objects still were using a default of 0.2, likely explaining the slew of bad results I've been seeing for a while.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized temperature default configuration across examples and core modules for improved maintainability.

* **Tests**
  * Updated test fixtures and assertions to align with centralized temperature configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->