### PR TITLE
Add 'skip block' functionality for short blocks

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -201,6 +201,10 @@ class PhaseConfig:
     use_subblocks: bool = False
     max_subblock_tokens: int = DEFAULT_MAX_SUBBLOCK_TOKENS
     min_subblock_tokens: int = DEFAULT_MIN_SUBBLOCK_TOKENS
+    # Block skipping parameter
+    # If set, blocks with fewer tokens than this value will be skipped entirely
+    # (before chunking into subblocks). Default None means no skipping.
+    skip_if_less_than_tokens: Optional[int] = None
     # Two-stage phase configuration (required for FINAL_TWO_STAGE)
     two_stage_config: Optional[TwoStageModelConfig] = None
 

--- a/src/phase_factory.py
+++ b/src/phase_factory.py
@@ -218,6 +218,7 @@ class PhaseFactory:
             "use_subblocks": config.use_subblocks,
             "max_subblock_tokens": config.max_subblock_tokens,
             "min_subblock_tokens": config.min_subblock_tokens,
+            "skip_if_less_than_tokens": config.skip_if_less_than_tokens,
         }
 
     @staticmethod
@@ -382,6 +383,7 @@ class PhaseFactory:
             batch_size=config.batch_size,
             enable_retry=config.enable_retry,
             max_retries=config.max_retries,
+            skip_if_less_than_tokens=config.skip_if_less_than_tokens,
         )
 
     @staticmethod


### PR DESCRIPTION
Adds a parameter, at the phase level, that specifies a minimum token block size to be processed. Any blocks less than this size are simply skipped over by the process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable token count threshold setting that enables automatic skipping of blocks during phase processing. When a block's token count falls below the specified threshold, it is skipped and its original content is preserved without undergoing additional processing. This capability is now available for both standard phase processing and two-stage final phase workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->