### PR TITLE
Ensure that failed post-processor stops pipeline

### DIFF
--- a/src/post_processors.py
+++ b/src/post_processors.py
@@ -415,16 +415,12 @@ class PostProcessorChain(PostProcessor):
                 # EmptySectionError is a critical validation error that should stop the pipeline
                 logger.error(f"EmptySectionError in post-processor {processor.name} - propagating to stop pipeline")
                 raise
-            except (ValueError, KeyError, AttributeError, TypeError, IndexError) as e:
-                # Common post-processor errors are logged but non-fatal
-                logger.error(f"Error in post-processor {processor.name}: {str(e)}")
-                logger.exception("Post-processor error stack trace")
-                continue
             except Exception as e:
-                # Catch-all for unexpected errors; log and continue with chain
-                logger.error(f"Unexpected error in post-processor {processor.name}: {str(e)}")
-                logger.exception("Unexpected post-processor error stack trace")
-                continue
+                # All post-processor errors are critical and should stop the pipeline
+                # to prevent producing corrupt output
+                logger.error(f"Post-processor {processor.name} failed: {str(e)}")
+                logger.exception("Post-processor error stack trace")
+                raise RuntimeError(f"Post-processing failed at processor {processor.name}. ") from e
 
         logger.debug(f"Post-processing chain completed. Final block length: {len(current_block)} characters")
         return current_block

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -210,7 +210,7 @@ class TestPostProcessorConfigurationEdgeCases:
         assert "{лицензия}" in result
 
     def test_processor_chain_with_failing_processor(self):
-        """Test processor chain resilience when one processor fails."""
+        """Test processor chain fails fast when one processor fails."""
 
         class FailingProcessor:
             def __init__(self):
@@ -231,11 +231,11 @@ class TestPostProcessorConfigurationEdgeCases:
         chain.add_processor(FailingProcessor())
         chain.add_processor(WorkingProcessor())
 
-        # Chain should continue processing despite failure
-        result = chain.process(original_block="", llm_block="old content old")
+        # Chain should fail fast when a processor raises an exception
+        with pytest.raises(RuntimeError) as exc_info:
+            chain.process(original_block="", llm_block="old content old")
 
-        # Should have processed with working processors despite failure
-        assert "new content new" in result
+        assert "Post-processing failed at processor failing_processor" in str(exc_info.value)
 
     def test_processor_with_extremely_large_config(self):
         """Test processor behavior with extremely large configuration."""


### PR DESCRIPTION
If a post processor fails, the pipeline is now stopped to ensure corrupted output does not propagate to future steps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Post-processor errors now halt the pipeline immediately instead of being logged and ignored, ensuring output integrity.

* **Tests**
  * Updated error handling tests to reflect fail-fast behavior on post-processing failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->