### PR TITLE
Ensure the Gemini batch processing uses model name

### DIFF
--- a/src/llm_model.py
+++ b/src/llm_model.py
@@ -1121,7 +1121,7 @@ class GeminiClient(ProviderClient):
         return False
 
     def _parse_batch_results(
-        self, result_content: str, original_requests: list[dict[str, Any]]
+        self, result_content: str, original_requests: list[dict[str, Any]], model_name: str
     ) -> list[dict[str, Any]]:
         """
         Parse batch job results and match them with original requests.
@@ -1129,6 +1129,7 @@ class GeminiClient(ProviderClient):
         Args:
             result_content: JSONL content from batch job results
             original_requests: Original request list for metadata matching
+            model_name: Name of the model used for the batch job
 
         Returns:
             List of response dictionaries
@@ -1191,7 +1192,7 @@ class GeminiClient(ProviderClient):
                         if prompt_tokens is not None or completion_tokens is not None:
                             register_generation_model_info(
                                 generation_id=generation_id,
-                                model="gemini",  # Model name from batch job
+                                model=model_name,
                                 prompt_tokens=prompt_tokens,
                                 completion_tokens=completion_tokens,
                                 is_batch=True,  # This is batch processing, apply 50% discount
@@ -1308,7 +1309,7 @@ class GeminiClient(ProviderClient):
                     result_content = result_bytes.decode("utf-8")
 
                     # Parse and return results
-                    responses = self._parse_batch_results(result_content, requests)
+                    responses = self._parse_batch_results(result_content, requests, model_name)
 
                     module_logger.info(f"Successfully processed {len(responses)} batch responses")
                     return responses


### PR DESCRIPTION
Ensure the registration of Gemini batch results uses the actual name instead of hardcoded named 'gemini'

@coderabbitai ignore