### PR TITLE
Raise error if missing key in template formatting

### DIFF
--- a/src/phases/base.py
+++ b/src/phases/base.py
@@ -411,8 +411,9 @@ class LlmPhase(ABC):
             ret = self.user_prompt.format(**context)
             return ret
         except KeyError as e:
-            logger.warning(f"User prompt contains undefined parameter: {e}")
-            return self.user_prompt
+            raise ValueError(
+                f"User prompt contains undefined parameter: {e}. Available context keys: {list(context.keys())}"
+            ) from e
 
     def _get_header_and_body(self, block: str) -> Tuple[str, str]:
         """


### PR DESCRIPTION
Raise an error if there is a missing key in template formatting rather than silently letting an unformatted template continue

@coderabbitai ignore