### PR TITLE
Added two stage config to support implement reasoning

### DIFF
--- a/src/api/config.py
+++ b/src/api/config.py
@@ -60,18 +60,19 @@ class TwoStageModelConfig(BaseConfig):
     identify_model: ModelConfig
     implement_model: ModelConfig
     identify_reasoning: dict[str, str] | None = None
+    implement_reasoning: dict[str, str] | None = None
 
-    @field_validator("identify_reasoning")
+    @field_validator("identify_reasoning", "implement_reasoning")
     @classmethod
-    def validate_identify_reasoning(cls, value: dict[str, str] | None) -> dict[str, str] | None:
+    def validate_reasoning_fields(cls, value: dict[str, str] | None, info: ValidationInfo) -> dict[str, str] | None:
         if value is None:
             return value
         if not isinstance(value, dict):
-            raise ValueError(f"identify_reasoning must be a dict[str, str] or None, got {type(value).__name__}")
+            raise ValueError(f"{info.field_name} must be a dict[str, str] or None, got {type(value).__name__}")
         for key, item in value.items():
             if not isinstance(key, str) or not isinstance(item, str):
                 raise ValueError(
-                    "identify_reasoning must be a dict[str, str]; "
+                    f"{info.field_name} must be a dict[str, str]; "
                     f"found key/value types ({type(key).__name__}, {type(item).__name__})"
                 )
         return value

--- a/src/phases/factory.py
+++ b/src/phases/factory.py
@@ -330,6 +330,7 @@ class PhaseFactory:
             model=implement_model,
             system_prompt=implement_system,
             user_prompt_template=implement_user,
+            reasoning=config.two_stage_config.implement_reasoning,
         )
 
         # Create post-processor chain (applies to IMPLEMENT output only)

--- a/tests/test_two_stage_final_phase.py
+++ b/tests/test_two_stage_final_phase.py
@@ -47,8 +47,9 @@ class TestTwoStageModelConfig:
         assert config.identify_model == identify_model
         assert config.implement_model == implement_model
         assert config.identify_reasoning is None
+        assert config.implement_reasoning is None
 
-    def test_config_with_reasoning(self):
+    def test_config_with_identify_reasoning(self):
         """Test creating config with identify_reasoning set."""
         identify_model = ModelConfig(
             provider=Provider.OPENROUTER,
@@ -68,6 +69,52 @@ class TestTwoStageModelConfig:
         )
 
         assert config.identify_reasoning == {"effort": "high"}
+        assert config.implement_reasoning is None
+
+    def test_config_with_implement_reasoning(self):
+        """Test creating config with implement_reasoning set."""
+        identify_model = ModelConfig(
+            provider=Provider.OPENROUTER,
+            model_id="deepseek/deepseek-r1",
+            provider_model_name="deepseek-r1",
+        )
+        implement_model = ModelConfig(
+            provider=Provider.GEMINI,
+            model_id="google/gemini-2.5-flash",
+            provider_model_name="gemini-2.5-flash",
+        )
+
+        config = TwoStageModelConfig(
+            identify_model=identify_model,
+            implement_model=implement_model,
+            implement_reasoning={"effort": "medium"},
+        )
+
+        assert config.identify_reasoning is None
+        assert config.implement_reasoning == {"effort": "medium"}
+
+    def test_config_with_both_reasoning(self):
+        """Test creating config with both identify and implement reasoning set."""
+        identify_model = ModelConfig(
+            provider=Provider.OPENROUTER,
+            model_id="deepseek/deepseek-r1",
+            provider_model_name="deepseek-r1",
+        )
+        implement_model = ModelConfig(
+            provider=Provider.GEMINI,
+            model_id="google/gemini-2.5-flash",
+            provider_model_name="gemini-2.5-flash",
+        )
+
+        config = TwoStageModelConfig(
+            identify_model=identify_model,
+            implement_model=implement_model,
+            identify_reasoning={"effort": "high"},
+            implement_reasoning={"effort": "low"},
+        )
+
+        assert config.identify_reasoning == {"effort": "high"}
+        assert config.implement_reasoning == {"effort": "low"}
 
     def test_invalid_identify_model_type(self):
         """Test that invalid identify_model type raises ValidationError."""
@@ -97,7 +144,7 @@ class TestTwoStageModelConfig:
                 implement_model="not_a_model_config",  # type: ignore
             )
 
-    def test_invalid_reasoning_type(self):
+    def test_invalid_identify_reasoning_type(self):
         """Test that non-dict identify_reasoning raises ValidationError."""
         identify_model = ModelConfig(
             provider=Provider.OPENROUTER,
@@ -117,7 +164,27 @@ class TestTwoStageModelConfig:
                 identify_reasoning="not_a_dict",  # type: ignore
             )
 
-    def test_invalid_reasoning_key_type(self):
+    def test_invalid_implement_reasoning_type(self):
+        """Test that non-dict implement_reasoning raises ValidationError."""
+        identify_model = ModelConfig(
+            provider=Provider.OPENROUTER,
+            model_id="deepseek/deepseek-r1",
+            provider_model_name="deepseek-r1",
+        )
+        implement_model = ModelConfig(
+            provider=Provider.GEMINI,
+            model_id="google/gemini-2.5-flash",
+            provider_model_name="gemini-2.5-flash",
+        )
+
+        with pytest.raises(ValidationError):
+            TwoStageModelConfig(
+                identify_model=identify_model,
+                implement_model=implement_model,
+                implement_reasoning="not_a_dict",  # type: ignore
+            )
+
+    def test_invalid_identify_reasoning_key_type(self):
         """Test that non-string keys in identify_reasoning raise ValidationError."""
         identify_model = ModelConfig(
             provider=Provider.OPENROUTER,
@@ -135,6 +202,26 @@ class TestTwoStageModelConfig:
                 identify_model=identify_model,
                 implement_model=implement_model,
                 identify_reasoning={123: "value"},  # type: ignore
+            )
+
+    def test_invalid_implement_reasoning_key_type(self):
+        """Test that non-string keys in implement_reasoning raise ValidationError."""
+        identify_model = ModelConfig(
+            provider=Provider.OPENROUTER,
+            model_id="deepseek/deepseek-r1",
+            provider_model_name="deepseek-r1",
+        )
+        implement_model = ModelConfig(
+            provider=Provider.GEMINI,
+            model_id="google/gemini-2.5-flash",
+            provider_model_name="gemini-2.5-flash",
+        )
+
+        with pytest.raises(ValidationError):
+            TwoStageModelConfig(
+                identify_model=identify_model,
+                implement_model=implement_model,
+                implement_reasoning={123: "value"},  # type: ignore
             )
 
 


### PR DESCRIPTION
Add support in the two stage config for reasoning in both sub phases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional reasoning configuration for the implement stage, enabling separate reasoning settings for identify and implement stages in two-stage models.

* **Tests**
  * Expanded test coverage to validate implement-stage reasoning configuration and type validation scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->